### PR TITLE
Set up GitHub Actions for Tox testing and linting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,50 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+
+    strategy:
+      matrix:
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Run tox
+        run: tox -e py${{ matrix.python-version }}
+
+  lint:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Run flake8
+        run: tox -e flake8
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ABI Fragment Set Manager
 
+[![Tests](https://github.com/voteagora/abifsm/actions/workflows/tests.yml/badge.svg)](https://github.com/voteagora/abifsm/actions/workflows/tests.yml)
+
 A library for working with sets of EVM contracts and their ABIs, mostly for getting consistent naming conventions and working with topics.
 
 Basically syntatic sugar for...

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, flake8
+envlist = py36, py37, py38, py310, py311, py312, flake8
 
 [travis]
 python =
@@ -17,6 +17,7 @@ setenv =
     PYTHONPATH = {toxinidir}
 deps =
     -r{toxinidir}/requirements_dev.txt
+    -r{toxinidir}/requirements.txt
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following line:
 ;     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Runs tests on Python 3.9, 3.10, & 3.11, skipping deprecated versions.
Keeps older versions in `tox.ini` as they are seem used by Travis.
Note that flake8 fails due to E261, E302, and E501 violations, this could either be addressed or added to the ignore list.